### PR TITLE
close files opened with bioformats

### DIFF
--- a/modularPipeline.m
+++ b/modularPipeline.m
@@ -59,7 +59,7 @@ function modularPipeline()
     % get size Metadata - assuming same for all PSF channels
     r=bfGetReader(psfArray(1).fullpath);
     psf_metadata = getSizeMetadata(r,0);
-
+    r.close();
     fprintf('Selected PSF files:\n');
     disp(config.PSFFullpaths);
     fprintf('Channel Patterns:\n');
@@ -121,6 +121,7 @@ function modularPipeline()
                 if strcmp(config.processingMode, 'decon+deskew') || strcmp(config.processingMode, 'both')
                     r=bfGetReader(filePaths{1});
                     tif3D_metadata = getSizeMetadata(r,0);
+                    r.close();
                     if (tif3D_metadata.pixelSizeZ == psf_metadata.pixelSizeZ)
                         runDeconDeskewPipeline(seriesResult, config);
                     else
@@ -183,6 +184,7 @@ function processSldFile(sldFileName, config, psf_metadata)
         end
         deleteIntermediateFiles(seriesResult.tifDir, config);
     end
+    r.close();
 end
 
 %% -----------------------------------------------------------------------


### PR DESCRIPTION
This pull request addresses resource management issues in the `modularPipeline.m` file by ensuring proper closure of file readers (`r`) after their use. This change prevents potential resource leaks and improves the stability of the pipeline.

### Resource management improvements:
* [`modularPipeline.m`](diffhunk://#diff-37b6eec8b7b0758613d029a8be8446ae9b09af0cf499fe55e0e4e612ff90b9f6L62-R62): Added `r.close()` after retrieving PSF metadata in the `modularPipeline()` function to ensure the file reader is closed.
* [`modularPipeline.m`](diffhunk://#diff-37b6eec8b7b0758613d029a8be8446ae9b09af0cf499fe55e0e4e612ff90b9f6R124): Added `r.close()` after retrieving TIF 3D metadata in the `modularPipeline()` function to properly release the file reader resource.
* [`modularPipeline.m`](diffhunk://#diff-37b6eec8b7b0758613d029a8be8446ae9b09af0cf499fe55e0e4e612ff90b9f6R187): Added `r.close()` at the end of the `processSldFile()` function to ensure the file reader is closed before exiting the function.